### PR TITLE
Fix reference to undefined property "_controls" install error

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -23,11 +23,11 @@ class WorkspaceTitle {
 
 	getThumbnails() {
 		const overview = Main.overview;
-		if (overview._controls && overview._controls._thumbnailsBox && overview._controls._thumbnailsBox._thumbnails) {
-			return overview._controls._thumbnailsBox._thumbnails;
-		}
-		if (overview._overview && overview._overview._controls && overview._overview._controls._thumbnailsBox && overview._overview._controls._thumbnailsBox._thumbnails) {
+		if (overview._overview._controls && overview._overview._controls._thumbnailsBox && overview._overview._controls._thumbnailsBox._thumbnails) {
 			return overview._overview._controls._thumbnailsBox._thumbnails;
+		}
+		if (overview._overview && overview._overview._overview._controls && overview._overview._overview._controls._thumbnailsBox && overview._overview._overview._controls._thumbnailsBox._thumbnails) {
+			return overview._overview._overview._controls._thumbnailsBox._thumbnails;
 		}
 		throw new Error('Could not find thumbnails, please raise a bug');
 	}


### PR DESCRIPTION
I'm not a javascript guy but the proposed changes got it working with a manual install on my system under Gnome 3.36.8,  I also double checked that version 3 was installed from the Gnome extensions website and errored out as described before making these changes.